### PR TITLE
Should solve issue #7

### DIFF
--- a/ruby/bin/enclient.rb
+++ b/ruby/bin/enclient.rb
@@ -86,11 +86,11 @@ module EnClient
         end
       end
       fields.delete nil
-      fields.join "\u0000"
+      fields.join ","
     end
 
     def deserialize(str)
-      fields = str.split "\u0000"
+      fields = str.split ","
       fields.each do |f|
         f =~ /\A([^=]*)=(.*)\z/
         varsym = $1.to_sym


### PR DESCRIPTION
Hi,

I have encountered the same problem as issue #7 and created a patch to fix it.  Could you check it and merge it to the master branch if it seems fine?

Firstly, I changed the Serializable.deserialize method so that it could handle a object with type field_type_object.

However, after that, I encountered another problem that a serialized string for a NoteAttributes object was failed to be deserialized because it contains a key-value pair, 'sourceApplication=emacs-enclient {:version => 0.21, :editmode => "TEXT"}', which could cause a deserialization error as it has a comma in it.

Then, I changed the type of sourceApplication form "field_type_string" to "field_type_base64".

Thanks.
