### PR TITLE
ignore to set value when gdbm has invalid value.

### DIFF
--- a/ruby/bin/enclient.rb
+++ b/ruby/bin/enclient.rb
@@ -93,11 +93,13 @@ module EnClient
       fields = str.split ","
       fields.each do |f|
         f =~ /\A([^=]*)=(.*)\z/
+        if $1.nil? then
+          next;
+        end
         varsym = $1.to_sym
         varval_str = $2
         vartype = serialized_fields[varsym]
         #puts "[#{varsym}], [#{varval_str}], [#{vartype}]"
-
         varval =
           if varval_str
             case vartype


### PR DESCRIPTION
issue #11 happens on my environment when I use get_result_from_local_cache func in ListNoteCommand.
Because GDBM has a invalid value that regular expression can not parse.
I don't know why that value is stored. But I ignore this value so that it can open note.

Sorry for previous requests and Please check and merge unless it has problems.
