### PR TITLE
Fix the issue 18

### DIFF
--- a/ruby/bin/enclient.rb
+++ b/ruby/bin/enclient.rb
@@ -1837,6 +1837,11 @@ module EnClient
     def self.to_ascii(*rest)
       if IS_FORCE_ENCODING_SUPPORTED
         rest.each do |elem|
+          if elem
+           if elem.bytesize > elem.length
+             return
+           end
+          end
           elem.force_encoding Encoding::ASCII_8BIT if elem
         end
       end


### PR DESCRIPTION
 Avoid to send string which is 2 byte character by ascii-8bit format.
As i see, String which passes the evernote library need to encode ascii-8bit as specification.
Hence, Error occurs by 2bytes character , which is Japanese or other lang.
For the time being, I made this fix sent 2bytes characters without encoding.
English is encoded by ascii-8 bit as usual. 
