### PR TITLE
use RbConfig instead of obsolete ::Config

### DIFF
--- a/ruby/setup.rb
+++ b/ruby/setup.rb
@@ -785,7 +785,7 @@ class ToplevelInstaller
     else
       require 'rbconfig'
     end
-    ::Config::CONFIG
+    RbConfig::CONFIG
   end
 
   def initialize(ardir_root, config)


### PR DESCRIPTION
This is a trivial change, given that you're already requiring 'rbconfig' instead of the old 'config.' This fixes at least #30 and #31 by adding compatibility with newer versions of Ruby. I tested installation with Ruby 2.3.0p0, and it appears to work properly now.
